### PR TITLE
Feature/bag player

### DIFF
--- a/ianvs/CMakeLists.txt
+++ b/ianvs/CMakeLists.txt
@@ -12,10 +12,15 @@ endif()
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 find_package(ament_cmake REQUIRED)
+find_package(Boost REQUIRED COMPONENTS filesystem system)
+find_package(CLI11 REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rosbag2_transport REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(tf2_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 add_library(
   ${PROJECT_NAME}
@@ -36,9 +41,16 @@ if(NOT BUILD_SHARED_LIBS)
   set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
+add_executable(play_rosbag app/play_rosbag.cpp)
+target_link_libraries(
+  play_rosbag PRIVATE rclcpp::rclcpp rosbag2_transport::rosbag2_transport Boost::system
+                      Boost::filesystem CLI11::CLI11
+)
+ament_target_dependencies(play_rosbag PUBLIC tf2_msgs tf2_ros)
+
 install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME}/)
 install(
-  TARGETS ${PROJECT_NAME}
+  TARGETS ${PROJECT_NAME} play_rosbag
   EXPORT ${PROJECT_NAME}-exports
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/ianvs/app/play_rosbag.cpp
+++ b/ianvs/app/play_rosbag.cpp
@@ -1,0 +1,110 @@
+#include <tf2_ros/static_transform_broadcaster.h>
+
+#include <filesystem>
+
+#include <CLI/CLI.hpp>
+#include <boost/process.hpp>
+#include <boost/process/args.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/serialization.hpp>
+#include <rosbag2_transport/reader_writer_factory.hpp>
+#include <tf2_msgs/msg/tf_message.hpp>
+
+using tf2_msgs::msg::TFMessage;
+namespace bp = boost::process;
+
+TFMessage::UniquePtr read_static_tfs(const rclcpp::Node& node,
+                                     const std::filesystem::path& bag_path) {
+  const auto logger = node.get_logger();
+  if (!std::filesystem::exists(bag_path)) {
+    return nullptr;
+  }
+
+  rclcpp::get_logger("rosbag2_storage").set_level(rclcpp::Logger::Level::Warn);
+  rosbag2_storage::StorageOptions storage_options;
+  storage_options.uri = bag_path;
+
+  const rclcpp::Serialization<TFMessage> serialization;
+  auto reader = rosbag2_transport::ReaderWriterFactory::make_reader(storage_options);
+  if (!reader) {
+    return nullptr;
+  }
+
+  auto all_tfs = std::make_unique<TFMessage>();
+  RCLCPP_DEBUG_STREAM(node.get_logger(), "reading static tfs from " << bag_path);
+
+  reader->open(storage_options);
+  rosbag2_storage::StorageFilter filter;
+  filter.topics = {"/tf_static"};
+  reader->set_filter(filter);
+  while (reader->has_next()) {
+    const auto msg = reader->read_next();
+    rclcpp::SerializedMessage serialized_msg(*msg->serialized_data);
+    auto tf_msg = std::make_shared<TFMessage>();
+    serialization.deserialize_message(&serialized_msg, tf_msg.get());
+    all_tfs->transforms.insert(all_tfs->transforms.end(),
+                               tf_msg->transforms.begin(),
+                               tf_msg->transforms.end());
+  }
+
+  RCLCPP_DEBUG_STREAM(node.get_logger(), "finished reading static tfs");
+  if (all_tfs->transforms.empty()) {
+    return nullptr;
+  }
+
+  return all_tfs;
+}
+
+int main(int argc, char** argv) {
+  CLI::App app;
+  argv = app.ensure_utf8(argv);
+  app.allow_extras();
+
+  // NOTE(nathan) for whatever reason, this doesn't get handled correctly when we use
+  // the -- separator and multiple bags, so I give up
+  std::string bag_path;
+  app.add_option("bag_path", bag_path)->required()->check(CLI::ExistingPath);
+
+  std::string message;
+  app.add_option("-m,--message", message, "fake arg");
+
+  try {
+    app.parse(argc, argv);
+  } catch (const CLI::ParseError& e) {
+    return app.exit(e);
+  }
+
+  std::vector<std::string> cmd_args{"bag", "play", bag_path};
+  bool added_exclude = false;
+  for (const auto& arg : app.remaining()) {
+    if (arg == "--") {
+      continue;
+    }
+
+    cmd_args.push_back(arg);
+    if (arg == "--exclude-topics") {
+      cmd_args.push_back("/tf_static");
+      added_exclude = true;
+    }
+  }
+
+  if (!added_exclude) {
+    cmd_args.push_back("--exclude-topics");
+    cmd_args.push_back("/tf_static");
+  }
+
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<rclcpp::Node>("tf_republisher");
+  auto tf_msg = read_static_tfs(*node, bag_path);
+  if (tf_msg) {
+     auto broadcaster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node);
+     broadcaster->sendTransform(tf_msg->transforms);
+  }
+
+  bp::child child(bp::search_path("ros2"), bp::args(cmd_args));
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+
+  child.wait();
+  return child.exit_code();
+}

--- a/ianvs/package.xml
+++ b/ianvs/package.xml
@@ -8,10 +8,16 @@
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>cli11</depend>
   <depend>message_filters</depend>
   <depend>rclcpp</depend>
+  <depend>rosbag2_transport</depend>
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>tf2_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>libboost-system-dev</depend>
+  <depend>libboost-filesystem-dev</depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
@yunzc @GoldenZephyr wrapper around rosbag that handles republishing static tfs before starting. I've only directly implemented adding frame prefixes, but will work on getting the other regex infrastructure in that we talked about.

Example invocation:
```
ros2 run ianvs play_rosbag /data/datasets/kimera_multi/outdoor_10_14/acl_jackal2 \
 -p sparkal2/ -- --clock -r 0.5 --exclude-topics /acl_jackal2/detection_out_topic /tf
```